### PR TITLE
Keep `Memory` cache when notebook cell changes

### DIFF
--- a/joblib/func_inspect.py
+++ b/joblib/func_inspect.py
@@ -144,11 +144,18 @@ def get_func_name(func, resolv_alias=True, win_characters=True):
                 parts[-1] = '-'.join(splitted[:2] + splitted[3:])
             elif len(parts) > 2 and parts[-2].startswith('ipykernel_'):
                 # In a notebook session (ipykernel). Filename seems to be 'xyz'
-                # of above. parts[-2] has the structure ipykernel_XXXXXX where
-                # XXXXXX is a six-digit number identifying the current run (?).
-                # If we split it off, the function again has the same
-                # identifier across runs.
+                # of above. `parts` variable's value is structured like this:
+                # ['', 'tmp', 'ipykernel_25910', '649976777.py']
+                # The numbers in `part[-2]` change change when kernel restarts.
+                # `parts[-1]` changes when any code in notebook cell changes.
+                # We want to ignore both
+                # - the changed notebook session, when kernel restarts
+                # - the arbitrary changes in notebook cell code
+                # The latter is because cache needs to be invalidated when the code
+                # of function changes, rather than *any* code in the notebook cell 
+                # where the function is defined.
                 parts[-2] = 'ipykernel'
+                del parts[-1]
             filename = '-'.join(parts)
             if filename.endswith('.py'):
                 filename = filename[:-3]


### PR DESCRIPTION
#1214 modifies `get_func_name` function to prevent invalidating the cache when jupyter notebook kernel restarts.

This PR further modifies `get_func_name` to prevent invalidating cache, when the notebook cell, which contains the cached function, changes.

This is desirable, because we only want to invalidate the cache when the function code changes, rather than arbitrary code in the cell where the function is defined.

Tracking the function code change is already properly implemented via `get_func_code`.

I have tested the change manually by monkey-patching `get_func_name` and using `Memory(verbose=True)` to see, what name is assigned to the function cache, and whether cache is hit or not.

Cache is invalidated on jupyter kernel restart:
- before this change: No
- after this change: No

Cache is invalidated on code change in notebook cell outside the cached function
- before this change: Yes
- after this change: No

Cache is invalidated on code change within the cached function
- before this change: Yes
- after this change: Yes